### PR TITLE
fix: don't hard fail when serializing failed

### DIFF
--- a/src/api/AbstractObject.ts
+++ b/src/api/AbstractObject.ts
@@ -178,7 +178,7 @@ export abstract class AbstractObject<
           // @ts-expect-error: tried my best lol
           json[key] = resolvedValue;
         } else {
-          throw new Error(util.format("Unable to serialize object: %O", value));
+          console.warn(util.format("Unable to serialize object: %O", value));
         }
       }
     }


### PR DESCRIPTION
In my project scenario this case failed for me. It was trying to serialise a string/uuid:

```
[Malformed Xcode project]: Found orphaned reference: 79332038C44045AD94B3A9FB > PBXTargetDependency.targetProxy > 68D8C8772B28CFF300FF65DB
[Malformed Xcode project]: Found orphaned reference: 096AE6AA28DE43C8996B60E0 > PBXTargetDependency.targetProxy > 68D8C8782B28CFF300FF65DB
[Malformed Xcode project]: Found orphaned reference: E408E5530DA04F7487D5646D > PBXTargetDependency.targetProxy > 68D8C8792B28CFF300FF65DB
[Malformed Xcode project]: Found orphaned reference: EE6CD26D29074DF499E3D6D6 > PBXTargetDependency.targetProxy > F186507EA3414BFCB686D489
[Malformed Xcode project]: Found orphaned reference: 241EA4F9F32C4ED7930D0229 > PBXTargetDependency.targetProxy > 09A87CA44CFA41E3BEDA4063
[Malformed Xcode project]: Found orphaned reference: 13B07F861A680F5B00A75B9A > PBXNativeTarget.buildPhases > 318C3A8FB1A0467E8F8B864D

✖ Config sync failed

Error: [ios.xcodeProjectBeta]: withIosXcodeProjectBetaBaseMod: Unable to serialize object: '68D8C8772B28CFF300FF65DB'
```

Instead of failing I just thought we could return a warning here?
However, I understand that It might be better to find the root cause why its failing.