### PR TITLE
feat: add spm support

### DIFF
--- a/src/api/PBXProject.ts
+++ b/src/api/PBXProject.ts
@@ -13,6 +13,7 @@ import type { PBXAggregateTarget } from "./PBXAggregateTarget";
 import type { PBXLegacyTarget } from "./PBXLegacyTarget";
 import type { XCConfigurationList } from "./XCConfigurationList";
 import type { XCRemoteSwiftPackageReference } from "./XCRemoteSwiftPackageReference";
+import type { XCLocalSwiftPackageReference } from "./XCLocalSwiftPackageReference";
 
 export type PBXProjectModel = json.PBXProject<
   XCConfigurationList,
@@ -20,7 +21,7 @@ export type PBXProjectModel = json.PBXProject<
   PBXGroup,
   /* any target */
   PBXAggregateTarget | PBXLegacyTarget | PBXNativeTarget,
-  XCRemoteSwiftPackageReference
+  XCRemoteSwiftPackageReference | XCLocalSwiftPackageReference
 >;
 
 export class PBXProject extends AbstractObject<PBXProjectModel> {

--- a/src/api/XCLocalSwiftPackageReference.ts
+++ b/src/api/XCLocalSwiftPackageReference.ts
@@ -1,0 +1,34 @@
+import * as json from "../json/types";
+import { AbstractObject } from "./AbstractObject";
+
+import type { SansIsa } from "./utils/util.types";
+import type { XcodeProject } from "./XcodeProject";
+
+export type XCLocalSwiftPackageReferenceModel =
+  json.XCLocalSwiftPackageReference;
+
+export class XCLocalSwiftPackageReference extends AbstractObject<XCLocalSwiftPackageReferenceModel> {
+  static isa = json.ISA.XCLocalSwiftPackageReference as const;
+
+  static is(object: any): object is XCLocalSwiftPackageReference {
+    return object.isa === XCLocalSwiftPackageReference.isa;
+  }
+
+  static create(
+    project: XcodeProject,
+    opts: SansIsa<XCLocalSwiftPackageReferenceModel>
+  ) {
+    return project.createModel<XCLocalSwiftPackageReferenceModel>({
+      isa: XCLocalSwiftPackageReference.isa,
+      ...opts,
+    }) as XCLocalSwiftPackageReference;
+  }
+
+  protected getObjectProps() {
+    return {};
+  }
+
+  getDisplayName(): string {
+    return this.props.relativePath ?? super.getDisplayName();
+  }
+}

--- a/src/api/XCSwiftPackageProductDependency.ts
+++ b/src/api/XCSwiftPackageProductDependency.ts
@@ -4,9 +4,12 @@ import { AbstractObject } from "./AbstractObject";
 import type { SansIsa } from "./utils/util.types";
 import type { XcodeProject } from "./XcodeProject";
 import type { XCRemoteSwiftPackageReference } from "./XCRemoteSwiftPackageReference";
+import type { XCLocalSwiftPackageReference } from "./XCLocalSwiftPackageReference";
 
 export type XCSwiftPackageProductDependencyModel =
-  json.XCSwiftPackageProductDependency<XCRemoteSwiftPackageReference>;
+  json.XCSwiftPackageProductDependency<
+    XCRemoteSwiftPackageReference | XCLocalSwiftPackageReference
+  >;
 
 export class XCSwiftPackageProductDependency extends AbstractObject<XCSwiftPackageProductDependencyModel> {
   static isa = json.ISA.XCSwiftPackageProductDependency as const;

--- a/src/api/XcodeProject.ts
+++ b/src/api/XcodeProject.ts
@@ -138,6 +138,11 @@ const KNOWN_ISA = {
   [json.ISA.PBXRezBuildPhase]: () =>
     require("./PBXSourcesBuildPhase")
       .PBXRezBuildPhase as typeof import("./PBXSourcesBuildPhase").PBXRezBuildPhase,
+  [json.ISA.XCSwiftPackageProductDependency]: () =>
+    require("./XCSwiftPackageProductDependency")
+      .XCSwiftPackageProductDependency,
+  [json.ISA.XCRemoteSwiftPackageReference]: () =>
+    require("./XCRemoteSwiftPackageReference").XCRemoteSwiftPackageReference,
 } as const;
 
 type AnyModel = ValueOf<IsaMapping>;

--- a/src/api/XcodeProject.ts
+++ b/src/api/XcodeProject.ts
@@ -143,6 +143,8 @@ const KNOWN_ISA = {
       .XCSwiftPackageProductDependency,
   [json.ISA.XCRemoteSwiftPackageReference]: () =>
     require("./XCRemoteSwiftPackageReference").XCRemoteSwiftPackageReference,
+  [json.ISA.XCLocalSwiftPackageReference]: () =>
+    require("./XCLocalSwiftPackageReference").XCLocalSwiftPackageReference,
 } as const;
 
 type AnyModel = ValueOf<IsaMapping>;

--- a/src/api/__tests__/XcodeProject.test.ts
+++ b/src/api/__tests__/XcodeProject.test.ts
@@ -19,3 +19,33 @@ it(`asserts useful error message when malformed`, () => {
     )
   );
 });
+
+describe("parse", () => {
+  const fixtures = [
+    "006-spm.pbxproj",
+    "AFNetworking.pbxproj",
+    // "Cocoa-Application.pbxproj",
+    // "project-multitarget-missing-targetattributes.pbxproj",
+    // "project-multitarget.pbxproj",
+    // "project-rni.pbxproj",
+    // "project-swift.pbxproj",
+    // "project-with-entitlements.pbxproj",
+    // "project-with-incorrect-create-manifest-ios-path.pbxproj",
+    // "project-without-create-manifest-ios.pbxproj",
+    "project.pbxproj",
+    "project-rn74.pbxproj",
+    // "swift-protobuf.pbxproj",
+    // "watch.pbxproj",
+  ];
+
+  fixtures.forEach((fixture) => {
+    it(`should parse ${fixture}`, () => {
+      const filePath = path.join(
+        __dirname,
+        "../../json/__tests__/fixtures/",
+        fixture
+      );
+      const project = XcodeProject.open(filePath);
+    });
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,5 +27,6 @@ export { AbstractObject } from "./AbstractObject";
 export { XCBuildConfiguration } from "./XCBuildConfiguration";
 export { XCConfigurationList } from "./XCConfigurationList";
 export { XCRemoteSwiftPackageReference } from "./XCRemoteSwiftPackageReference";
+export { XCLocalSwiftPackageReference } from "./XCLocalSwiftPackageReference";
 export { XCSwiftPackageProductDependency } from "./XCSwiftPackageProductDependency";
 export { XCVersionGroup } from "./XCVersionGroup";

--- a/src/json/__tests__/fixtures/006-spm.pbxproj
+++ b/src/json/__tests__/fixtures/006-spm.pbxproj
@@ -1,0 +1,765 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		4A2DFADC262D457F93E2D311 /* index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521098F6DCCB42F7B41B49B8 /* index.swift */; };
+		96905EF65AED1B983A6B3ABC /* libPods-xcodespmrepro.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-xcodespmrepro.a */; };
+		AC9C55BE2BD9246500041977 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = AC9C55BD2BD9246500041977 /* Supabase */; };
+		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		C72FCF45A381489ABC813413 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD352F99201A432E97962036 /* Assets.xcassets */; };
+		E10155BB10B34AA8BCC3A703 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168A10E62EA44CACABB120AE /* noop-file.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8F48896C666F489880110099 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCA0157385AE428CB5B4F71F;
+			remoteInfo = watchApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		13B07F961A680F5B00A75B9A /* xcodespmrepro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; fileEncoding = 4; includeInIndex = 0; path = xcodespmrepro.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = xcodespmrepro/AppDelegate.h; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = xcodespmrepro/AppDelegate.mm; sourceTree = "<group>"; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = xcodespmrepro/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = Info.plist; path = xcodespmrepro/Info.plist; sourceTree = "<group>"; };
+		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; name = main.m; path = xcodespmrepro/main.m; sourceTree = "<group>"; };
+		168A10E62EA44CACABB120AE /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "xcodespmrepro/noop-file.swift"; sourceTree = "<group>"; };
+		2806419CF98149498EF09C73 /* watchApp.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 4; includeInIndex = 0; name = watchApp.appex; path = watchApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		521098F6DCCB42F7B41B49B8 /* index.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; path = index.swift; sourceTree = "<group>"; };
+		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-xcodespmrepro.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; fileEncoding = 4; includeInIndex = 0; path = "libPods-xcodespmrepro.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C2E3173556A471DD304B334 /* Pods-xcodespmrepro.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xcodespmrepro.debug.xcconfig"; path = "Target Support Files/Pods-xcodespmrepro/Pods-xcodespmrepro.debug.xcconfig"; sourceTree = "<group>"; };
+		7A4D352CD337FB3A3BF06240 /* Pods-xcodespmrepro.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xcodespmrepro.release.xcconfig"; path = "Target Support Files/Pods-xcodespmrepro/Pods-xcodespmrepro.release.xcconfig"; sourceTree = "<group>"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = xcodespmrepro/SplashScreen.storyboard; sourceTree = "<group>"; };
+		AB9115529F0C420BAB108732 /* xcodespmrepro-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "xcodespmrepro-Bridging-Header.h"; path = "xcodespmrepro/xcodespmrepro-Bridging-Header.h"; sourceTree = "<group>"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		DD352F99201A432E97962036 /* Assets.xcassets */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F7177A59559747028CC4BEF0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-xcodespmrepro/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96905EF65AED1B983A6B3ABC /* libPods-xcodespmrepro.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F36788BF19F142CAA5116ED4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC9C55BE2BD9246500041977 /* Supabase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* xcodespmrepro */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
+				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				13B07FB71A68108700A75B9A /* main.m */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+				168A10E62EA44CACABB120AE /* noop-file.swift */,
+				AB9115529F0C420BAB108732 /* xcodespmrepro-Bridging-Header.h */,
+			);
+			name = xcodespmrepro;
+			sourceTree = "<group>";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-xcodespmrepro.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4C82DF7B102D412A8143726C /* expo:targets */ = {
+			isa = PBXGroup;
+			children = (
+				E2520DD8F45E439D80CBBE19 /* watch-app */,
+			);
+			name = expo:targets;
+			sourceTree = "<group>";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				4C82DF7B102D412A8143726C /* expo:targets */,
+				13B07FAE1A68108700A75B9A /* xcodespmrepro */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				D65327D7A22EEC0BE12398D9 /* Pods */,
+				D7E4C46ADA2E9064B798F356 /* ExpoModulesProviders */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* xcodespmrepro.app */,
+				2806419CF98149498EF09C73 /* watchApp.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		92DBD88DE9BF7D494EA9DA96 /* xcodespmrepro */ = {
+			isa = PBXGroup;
+			children = (
+				FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */,
+			);
+			name = xcodespmrepro;
+			sourceTree = "<group>";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = xcodespmrepro/Supporting;
+			sourceTree = "<group>";
+		};
+		D65327D7A22EEC0BE12398D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6C2E3173556A471DD304B334 /* Pods-xcodespmrepro.debug.xcconfig */,
+				7A4D352CD337FB3A3BF06240 /* Pods-xcodespmrepro.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		D7E4C46ADA2E9064B798F356 /* ExpoModulesProviders */ = {
+			isa = PBXGroup;
+			children = (
+				92DBD88DE9BF7D494EA9DA96 /* xcodespmrepro */,
+			);
+			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
+		E2520DD8F45E439D80CBBE19 /* watch-app */ = {
+			isa = PBXGroup;
+			children = (
+				521098F6DCCB42F7B41B49B8 /* index.swift */,
+				DD352F99201A432E97962036 /* Assets.xcassets */,
+				F7177A59559747028CC4BEF0 /* Info.plist */,
+			);
+			name = "watch-app";
+			path = "../targets/watch-app";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* xcodespmrepro */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "xcodespmrepro" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				239F5B34383D72F1DAD083AD /* [Expo] Configure project */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
+				A9B996B5E8C3EA5FBC2CD547 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				95C85A188A7A4DAA83C925A5 /* PBXTargetDependency */,
+			);
+			name = xcodespmrepro;
+			productName = xcodespmrepro;
+			productReference = 13B07F961A680F5B00A75B9A /* xcodespmrepro.app */;
+			productType = "com.apple.product-type.application";
+		};
+		DCA0157385AE428CB5B4F71F /* watchApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 718EB5DCB2D5430BA288F5B0 /* Build configuration list for PBXNativeTarget "watchApp" */;
+			buildPhases = (
+				E78FA71E7D314BADB0D4A1CF /* Sources */,
+				F36788BF19F142CAA5116ED4 /* Frameworks */,
+				4636EE1E8F2A49C4918C1A21 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = watchApp;
+			packageProductDependencies = (
+				AC9C55BD2BD9246500041977 /* Supabase */,
+			);
+			productName = watchApp;
+			productReference = 2806419CF98149498EF09C73 /* watchApp.appex */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1250;
+					};
+					DCA0157385AE428CB5B4F71F = {
+						CreatedOnToolsVersion = 14.3;
+						DevelopmentTeam = QQ57RJ5UTD;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "xcodespmrepro" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			packageReferences = (
+				AC9C55BC2BD9246500041977 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+			);
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* xcodespmrepro */,
+				DCA0157385AE428CB5B4F71F /* watchApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4636EE1E8F2A49C4918C1A21 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C72FCF45A381489ABC813413 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios relative | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-xcodespmrepro-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		239F5B34383D72F1DAD083AD /* [Expo] Configure project */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-xcodespmrepro/expo-configure-project.sh\"\n";
+		};
+		800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-xcodespmrepro/Pods-xcodespmrepro-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xcodespmrepro/Pods-xcodespmrepro-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A9B996B5E8C3EA5FBC2CD547 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-xcodespmrepro/Pods-xcodespmrepro-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-xcodespmrepro/Pods-xcodespmrepro-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
+				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */,
+				E10155BB10B34AA8BCC3A703 /* noop-file.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E78FA71E7D314BADB0D4A1CF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A2DFADC262D457F93E2D311 /* index.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		95C85A188A7A4DAA83C925A5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCA0157385AE428CB5B4F71F /* watchApp */;
+			targetProxy = 8F48896C666F489880110099 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C2E3173556A471DD304B334 /* Pods-xcodespmrepro.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = xcodespmrepro/xcodespmrepro.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = xcodespmrepro/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = com.hesselbom.xcodespmrepro;
+				PRODUCT_NAME = xcodespmrepro;
+				SWIFT_OBJC_BRIDGING_HEADER = "xcodespmrepro/xcodespmrepro-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7A4D352CD337FB3A3BF06240 /* Pods-xcodespmrepro.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = xcodespmrepro/xcodespmrepro.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				INFOPLIST_FILE = xcodespmrepro/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = com.hesselbom.xcodespmrepro;
+				PRODUCT_NAME = xcodespmrepro;
+				SWIFT_OBJC_BRIDGING_HEADER = "xcodespmrepro/xcodespmrepro-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		23D910FB377140149C1FD938 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "../targets/watch-app/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = watchApp;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.hesselbom.xcodespmrepro;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hesselbom.xcodespmrepro.watchApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WATCHOS_DEPLOYMENT_TARGET = 9.4;
+			};
+			name = Debug;
+		};
+		2FDC169E0F5549DCB967DAF6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "../targets/watch-app/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = watchApp;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.hesselbom.xcodespmrepro;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hesselbom.xcodespmrepro.watchApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WATCHOS_DEPLOYMENT_TARGET = 9.4;
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)  ";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				SDKROOT = iphoneos;
+				USE_HERMES = true;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)  ";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				SDKROOT = iphoneos;
+				USE_HERMES = true;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "xcodespmrepro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		718EB5DCB2D5430BA288F5B0 /* Build configuration list for PBXNativeTarget "watchApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				23D910FB377140149C1FD938 /* Debug */,
+				2FDC169E0F5549DCB967DAF6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "xcodespmrepro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		AC9C55BC2BD9246500041977 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AC9C55BD2BD9246500041977 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AC9C55BC2BD9246500041977 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/src/json/__tests__/json.test.ts
+++ b/src/json/__tests__/json.test.ts
@@ -5,6 +5,7 @@ import { inspect } from "util";
 
 describe(parse, () => {
   const fixtures = [
+    "006-spm.pbxproj",
     "AFNetworking.pbxproj",
     // "Cocoa-Application.pbxproj",
     // "project-multitarget-missing-targetattributes.pbxproj",
@@ -26,8 +27,8 @@ describe(parse, () => {
       const file = fs.readFileSync(filePath, "utf8");
       const result = parse(file);
       expect(result).toBeTruthy();
-      console.log(inspect(result, { depth: 5, colors: true }));
-      console.log(build(result));
+      // console.log(inspect(result, { depth: 5, colors: true }));
+      // console.log(build(result));
     });
 
     it(`should write the same pbxproj ${fixture}`, () => {
@@ -39,5 +40,4 @@ describe(parse, () => {
       expect(output).toEqual(file);
     });
   });
-
 });

--- a/src/json/comments.ts
+++ b/src/json/comments.ts
@@ -44,34 +44,6 @@ export function createReferenceList(
     return `Build configuration list for [unknown]`;
   }
 
-  function getXCRemoteSwiftPackageReferenceComment(id: string) {
-    for (const [innerId, obj] of Object.entries(objects) as any) {
-      if (obj.buildConfigurationList === id) {
-        let name = obj.name ?? obj.path ?? obj.productName;
-        if (!name) {
-          name =
-            objects[obj.targets?.[0]]?.productName ??
-            objects[obj.targets?.[0]]?.name;
-
-          if (!name) {
-            // NOTE(EvanBacon): I have no idea what I'm doing...
-            // this is for the case where the build configuration list is pointing to the main `PBXProject` object (no name).
-            // We locate the proxy (which may or may not be related) and use the remoteInfo property.
-            const proxy = Object.values(objects).find(
-              (obj: any) =>
-                obj.isa === "PBXContainerItemProxy" &&
-                obj.containerPortal === innerId
-            );
-            name = proxy?.remoteInfo;
-          }
-        }
-
-        return `${obj.isa} "${name}"`;
-      }
-    }
-    return id;
-  }
-
   function getBuildPhaseNameContainingFile(buildFileId: string): string | null {
     const buildPhase = Object.values(objects).find((obj: any) =>
       obj.files?.includes(buildFileId)

--- a/src/json/comments.ts
+++ b/src/json/comments.ts
@@ -4,6 +4,7 @@ import {
   PBXProject,
   XCConfigurationList,
   XCRemoteSwiftPackageReference,
+  XCLocalSwiftPackageReference,
   XcodeProject,
 } from "./types";
 
@@ -86,6 +87,12 @@ export function createReferenceList(
       } else {
         referenceCache[id] = object.isa;
       }
+    } else if (isXCLocalSwiftPackageReference(object)) {
+      if (object.relativePath) {
+        referenceCache[id] = `${object.isa} "${object.relativePath}"`;
+      } else {
+        referenceCache[id] = object.isa;
+      }
     } else if (isPBXProject(object)) {
       referenceCache[id] = "Project object";
     } else if (object.isa?.endsWith("BuildPhase")) {
@@ -151,6 +158,11 @@ function isXCRemoteSwiftPackageReference(
   val: any
 ): val is XCRemoteSwiftPackageReference {
   return val?.isa === "XCRemoteSwiftPackageReference";
+}
+function isXCLocalSwiftPackageReference(
+  val: any
+): val is XCLocalSwiftPackageReference {
+  return val?.isa === "XCLocalSwiftPackageReference";
 }
 
 function isXCConfigurationList(val: any): val is XCConfigurationList {

--- a/src/json/types.ts
+++ b/src/json/types.ts
@@ -41,6 +41,7 @@ export enum ISA {
   // spm
   XCSwiftPackageProductDependency = "XCSwiftPackageProductDependency",
   XCRemoteSwiftPackageReference = "XCRemoteSwiftPackageReference",
+  XCLocalSwiftPackageReference = "XCLocalSwiftPackageReference",
 }
 
 /** Indicates the relationship between a path and the project/system. */
@@ -525,7 +526,7 @@ export interface PBXBuildFile<TFileRef = UUID, TProductRef = UUID>
 
 export interface XCSwiftPackageProductDependency<TPackage = UUID>
   extends AbstractObject<ISA.XCSwiftPackageProductDependency> {
-  /** UUID for an object of type `XCRemoteSwiftPackageReference` */
+  /** UUID for an object of type `XCRemoteSwiftPackageReference` or `XCLocalSwiftPackageReference` */
   package?: TPackage;
 
   productName?: string;
@@ -537,6 +538,14 @@ export interface XCRemoteSwiftPackageReference
   repositoryURL: string;
   /** Version requirements. */
   requirement?: Record<string, any>;
+}
+
+export interface XCLocalSwiftPackageReference
+  extends AbstractObject<ISA.XCLocalSwiftPackageReference> {
+  /** URL the Swift package was installed from. */
+  path: string;
+  /** Repository path where the package is located relative to the Xcode project. */
+  relativePath: string;
 }
 
 export interface PBXContainerItemProxy<
@@ -665,7 +674,7 @@ export interface PBXProject<
   /** List of UUIDs for targets. */
   targets: TTargets[];
 
-  /** List of UUIDs for `XCRemoteSwiftPackageReference` */
+  /** List of UUIDs for `XCRemoteSwiftPackageReference` or `XCLocalSwiftPackageReference` */
   packageReferences?: TPackageReference[];
 }
 


### PR DESCRIPTION
- resolve https://github.com/EvanBacon/xcode/issues/6
- add `XCSwiftPackageProductDependency` and `XCRemoteSwiftPackageReference` object models.
- add custom comment format for `XCRemoteSwiftPackageReferenceComment`
- add tests for parsing and writing back to a matching file.
- add `XCLocalSwiftPackageReference` model