### PR TITLE
fix: preserve the string literal version when number exceed max safe integer

### DIFF
--- a/src/json/visitor/JsonVisitor.ts
+++ b/src/json/visitor/JsonVisitor.ts
@@ -78,12 +78,16 @@ function parseType(literal: string): number | string {
       return literal; // Preserve trailing zero
     }
     const num = parseFloat(literal);
+    // If numbers exceed the maximum safe integer, it should preserve the string version
+    if (num > Number.MAX_SAFE_INTEGER) return literal;
     if (!isNaN(num)) return num;
   }
   
   // Handle integers
   if (/^\d+$/.test(literal)) {
     const num = parseInt(literal, 10);
+    // If numbers exceed the maximum safe integer, it should preserve the string version
+    if (num > Number.MAX_SAFE_INTEGER) return literal;
     if (!isNaN(num)) return num;
   }
   


### PR DESCRIPTION
Spotted this issue in [React Native's RNTester](https://github.com/facebook/react-native/blob/5cb9187034ac9dc47476cb1680965aacf0312494/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj#L275-L281). It's a 1-in-a-million chance that the ISA ID is fully numeric, and in that case we accidentially evaluate it as number.

What's happening here is the following
- ISA ID `680759612239798500290469` is being parsed
- It's a numeric string, without `.` delimiter, so we parse it as int
- `parseInt('680759612239798500290469', 10) -> 6.807596122397985e+23`
- ISA ID is now set to `6.807596122397985e+23` instead of the original