### PR TITLE
Add modern SwiftUI multiplatform project types and fixture

### DIFF
--- a/src/json/__tests__/fixtures/010-swiftui-multiplatform.pbxproj
+++ b/src/json/__tests__/fixtures/010-swiftui-multiplatform.pbxproj
@@ -1,0 +1,356 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		CDD61D6F2F5CA7F700987C34 /* demo-multiplatform.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "demo-multiplatform.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		CDD61D712F5CA7F700987C34 /* demo-multiplatform */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "demo-multiplatform";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CDD61D6C2F5CA7F700987C34 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CDD61D662F5CA7F700987C34 = {
+			isa = PBXGroup;
+			children = (
+				CDD61D712F5CA7F700987C34 /* demo-multiplatform */,
+				CDD61D702F5CA7F700987C34 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CDD61D702F5CA7F700987C34 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CDD61D6F2F5CA7F700987C34 /* demo-multiplatform.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CDD61D6E2F5CA7F700987C34 /* demo-multiplatform */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDD61D7A2F5CA7F800987C34 /* Build configuration list for PBXNativeTarget "demo-multiplatform" */;
+			buildPhases = (
+				CDD61D6B2F5CA7F700987C34 /* Sources */,
+				CDD61D6C2F5CA7F700987C34 /* Frameworks */,
+				CDD61D6D2F5CA7F700987C34 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				CDD61D712F5CA7F700987C34 /* demo-multiplatform */,
+			);
+			name = "demo-multiplatform";
+			packageProductDependencies = (
+			);
+			productName = "demo-multiplatform";
+			productReference = CDD61D6F2F5CA7F700987C34 /* demo-multiplatform.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CDD61D672F5CA7F700987C34 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2630;
+				TargetAttributes = {
+					CDD61D6E2F5CA7F700987C34 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+				};
+			};
+			buildConfigurationList = CDD61D6A2F5CA7F700987C34 /* Build configuration list for PBXProject "demo-multiplatform" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CDD61D662F5CA7F700987C34;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = CDD61D702F5CA7F700987C34 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CDD61D6E2F5CA7F700987C34 /* demo-multiplatform */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CDD61D6D2F5CA7F700987C34 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CDD61D6B2F5CA7F700987C34 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		CDD61D782F5CA7F800987C34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CDD61D792F5CA7F800987C34 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		CDD61D7B2F5CA7F800987C34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.name.HelloWorld.demo-multiplatform";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Debug;
+		};
+		CDD61D7C2F5CA7F800987C34 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.name.HelloWorld.demo-multiplatform";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CDD61D6A2F5CA7F700987C34 /* Build configuration list for PBXProject "demo-multiplatform" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDD61D782F5CA7F800987C34 /* Debug */,
+				CDD61D792F5CA7F800987C34 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CDD61D7A2F5CA7F800987C34 /* Build configuration list for PBXNativeTarget "demo-multiplatform" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDD61D7B2F5CA7F800987C34 /* Debug */,
+				CDD61D7C2F5CA7F800987C34 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CDD61D672F5CA7F700987C34 /* Project object */;
+}

--- a/src/json/__tests__/json.test.ts
+++ b/src/json/__tests__/json.test.ts
@@ -33,6 +33,7 @@ describe(parse, () => {
     "007-xcode16.pbxproj",
     "008-out-of-order-orphans.pbxproj",
     "009-expo-app-clip.pbxproj",
+    "010-swiftui-multiplatform.pbxproj",
     "shopify-tophat.pbxproj",
     "AFNetworking.pbxproj",
     "project.pbxproj",
@@ -68,6 +69,7 @@ describe(parse, () => {
   const inOutFixtures = [
     "006-spm.pbxproj",
     "007-xcode16.pbxproj",
+    "010-swiftui-multiplatform.pbxproj",
 
     "AFNetworking.pbxproj",
     "project.pbxproj",

--- a/src/json/types.ts
+++ b/src/json/types.ts
@@ -234,10 +234,10 @@ export interface PBXFileSystemSynchronizedRootGroup<TException = UUID>
   extends AbstractPhysicalFileObject<ISA.PBXFileSystemSynchronizedRootGroup> {
   /** The list of exceptions applying to this group. */
   exceptions?: TException[];
-  /** Maps relative paths inside the synchronized root group to a particular file type. If a path doesn’t have a particular file type specified, Xcode defaults to the default file type based on the extension of the file. */
-  explicitFileTypes: Record<string, string>;
+  /** Maps relative paths inside the synchronized root group to a particular file type. If a path doesn't have a particular file type specified, Xcode defaults to the default file type based on the extension of the file. */
+  explicitFileTypes?: Record<string, string>;
   /** List of relative paths to children folder whose configuration is overwritten. */
-  explicitFolders: string[];
+  explicitFolders?: string[];
 }
 
 /** Object for referencing files that should be excluded from synchronization with the file system. */
@@ -900,8 +900,19 @@ export interface PBXProject<
   knownRegions: ("en" | "Base" | (string & {}))[];
   /** Object is a UUID for a `PBXGroup`. */
   mainGroup: TMainGroup;
+  /**
+   * Minimize reference proxies in the project.
+   * @example `1`
+   */
+  minimizedProjectReferenceProxies?: BoolNumber;
   /** Object is a UUID for a `PBXGroup`. */
   productRefGroup?: TProductRefGroup;
+  /**
+   * Preferred object version for the project.
+   * Used in modern Xcode projects (objectVersion 77+).
+   * @example `77`
+   */
+  preferredProjectObjectVersion?: number;
   /** Relative path for the project. */
   projectDirPath: string;
   /** Relative root path for the project. */
@@ -1043,6 +1054,8 @@ export interface BuildSettings {
   // INFOPLIST_KEY_LSApplicationCategoryType
 
   WATCHOS_DEPLOYMENT_TARGET?: string;
+  /** visionOS deployment target version. @example `"26.2"` */
+  XROS_DEPLOYMENT_TARGET?: string;
   MARKETING_VERSION?: number | string;
   SKIP_INSTALL?: BoolString;
   SWIFT_EMIT_LOC_STRINGS?: BoolString;
@@ -1068,7 +1081,13 @@ export interface BuildSettings {
   OTHER_LDFLAGS?: string[];
   SWIFT_COMPILATION_MODE?: "wholemodule" | (string & {});
   SWIFT_OPTIMIZATION_LEVEL?: "-O" | "-Onone" | "-Owholemodule" | (string & {});
-  SWIFT_VERSION?: "4.2" | "5" | (string & {});
+  SWIFT_VERSION?: "4.2" | "5" | "5.0" | (string & {});
+  /** Enables Swift's approachable concurrency mode. */
+  SWIFT_APPROACHABLE_CONCURRENCY?: BoolString;
+  /** Default actor isolation for Swift code. @example `"MainActor"` */
+  SWIFT_DEFAULT_ACTOR_ISOLATION?: "MainActor" | (string & {});
+  /** Enable Swift upcoming feature for member import visibility. */
+  SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY?: BoolString;
 
   ENABLE_USER_SCRIPT_SANDBOXING?: BoolString;
   ALWAYS_SEARCH_USER_PATHS?: BoolString;
@@ -1115,7 +1134,7 @@ export interface BuildSettings {
   "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]"?: BoolString;
   ENABLE_STRICT_OBJC_MSGSEND?: string;
   ENABLE_TESTABILITY?: string;
-  GCC_C_LANGUAGE_STANDARD?: "gnu11" | (string & {});
+  GCC_C_LANGUAGE_STANDARD?: "gnu11" | "gnu17" | (string & {});
   GCC_DYNAMIC_NO_PIC?: BoolString;
   GCC_NO_COMMON_BLOCKS?: BoolString;
   GCC_OPTIMIZATION_LEVEL?: string;
@@ -1147,4 +1166,24 @@ export interface BuildSettings {
   LOCALIZATION_PREFERS_STRING_CATALOGS?: BoolString;
   ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS?: BoolString;
   DEAD_CODE_STRIPPING?: BoolString;
+
+  // Modern SwiftUI multiplatform app settings
+  /** Enable App Sandbox for macOS apps. */
+  ENABLE_APP_SANDBOX?: BoolString;
+  /** Register app groups capability. */
+  REGISTER_APP_GROUPS?: BoolString;
+  /** Enable user-selected files access. @example `"readonly"` */
+  ENABLE_USER_SELECTED_FILES?: "readonly" | "readwrite" | (string & {});
+  /** Generate Swift symbols for string catalogs. */
+  STRING_CATALOG_GENERATE_SYMBOLS?: BoolString;
+
+  // SDK-specific build settings (platform-conditional)
+  "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]"?: BoolString;
+  "INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]"?: BoolString;
+  "INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]"?: BoolString;
+  "INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]"?: BoolString;
+  "INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]"?: BoolString;
+  "INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]"?: string;
+  "INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]"?: string;
+  "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]"?: string | string[];
 }


### PR DESCRIPTION
## Summary
- Add support for modern Xcode 16+ SwiftUI multiplatform projects (objectVersion 77)
- Add new PBXProject properties: `preferredProjectObjectVersion`, `minimizedProjectReferenceProxies`
- Fix `PBXFileSystemSynchronizedRootGroup` by making `explicitFileTypes` and `explicitFolders` optional
- Add new Swift 6 and visionOS build settings

## Changes
- **PBXProject**: Added `preferredProjectObjectVersion` and `minimizedProjectReferenceProxies`
- **BuildSettings**: Added `XROS_DEPLOYMENT_TARGET`, `SWIFT_APPROACHABLE_CONCURRENCY`, `SWIFT_DEFAULT_ACTOR_ISOLATION`, `SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY`, `ENABLE_APP_SANDBOX`, `REGISTER_APP_GROUPS`, `ENABLE_USER_SELECTED_FILES`, `STRING_CATALOG_GENERATE_SYMBOLS`
- **SDK-specific settings**: Added platform-conditional settings like `LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]`
- **Test fixture**: Added `010-swiftui-multiplatform.pbxproj` for a minimal modern SwiftUI multiplatform app

## Test plan
- [x] All 659 tests pass
- [x] New fixture round-trips correctly
- [x] API layer properly parses `fileSystemSynchronizedGroups` and new properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)