### PR TITLE
Update build settings and comment writer for Xcode 27

### DIFF
--- a/src/json/__tests__/fixtures/011-swift-ios-27.pbxproj
+++ b/src/json/__tests__/fixtures/011-swift-ios-27.pbxproj
@@ -1,0 +1,346 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 90;
+	objects = {
+
+/* Begin PBXFileReference section */
+		000000000000000000000120 /* swift-ios-27.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "swift-ios-27.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		000000000000000000000010 /* swift-ios-27 */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "swift-ios-27";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		000000000000000130000000 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+			);
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000010 /* swift-ios-27 */,
+				000000000000000000000020 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		000000000000000000000020 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000120 /* swift-ios-27.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		000000000000000100000000 /* swift-ios-27 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000110000000 /* Build configuration list for PBXNativeTarget "swift-ios-27" */;
+			buildPhases = (
+				000000000000000120000000 /* Sources */,
+				000000000000000130000000 /* Frameworks */,
+				000000000000000140000000 /* Resources */,
+			);
+			buildRules = (
+			);
+			fileSystemSynchronizedGroups = (
+				000000000000000000000010 /* swift-ios-27 */,
+			);
+			name = "swift-ios-27";
+			productName = MyApp;
+			productReference = 000000000000000000000120 /* swift-ios-27.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		000000000000000000000000 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2700;
+				TargetAttributes = {
+					000000000000000100000000 = {
+						CreatedOnToolsVersion = 26.3;
+					};
+				};
+			};
+			buildConfigurationList = 000000000000000010000000 /* Build configuration list for PBXProject "swift-ios-27" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 000000000000000000000001;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 90;
+			productRefGroup = 000000000000000000000020 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				000000000000000100000000 /* swift-ios-27 */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		000000000000000140000000 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		000000000000000120000000 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		000000000000000011000000 /* Debug configuration for PBXProject "swift-ios-27" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLETVOS_DEPLOYMENT_TARGET = 27.0;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DRIVERKIT_DEPLOYMENT_TARGET = 27.0;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PROJECT_UNIQUE_VALUE = AJSMPK5M;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				WATCHOS_DEPLOYMENT_TARGET = 27.0;
+				XROS_DEPLOYMENT_TARGET = 27.0;
+			};
+			name = Debug;
+		};
+		000000000000000012000000 /* Release configuration for PBXProject "swift-ios-27" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLETVOS_DEPLOYMENT_TARGET = 27.0;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DRIVERKIT_DEPLOYMENT_TARGET = 27.0;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 27.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 27.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PROJECT_UNIQUE_VALUE = AJSMPK5M;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				WATCHOS_DEPLOYMENT_TARGET = 27.0;
+				XROS_DEPLOYMENT_TARGET = 27.0;
+			};
+			name = Release;
+		};
+		000000000000000111000000 /* Debug configuration for PBXNativeTarget "swift-ios-27" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "devplaceholder.$(PROJECT_UNIQUE_VALUE:identifier).$(PRODUCT_NAME:identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Debug;
+		};
+		000000000000000112000000 /* Release configuration for PBXNativeTarget "swift-ios-27" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "devplaceholder.$(PROJECT_UNIQUE_VALUE:identifier).$(PRODUCT_NAME:identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		000000000000000010000000 /* Build configuration list for PBXProject "swift-ios-27" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000011000000 /* Debug configuration for PBXProject "swift-ios-27" */,
+				000000000000000012000000 /* Release configuration for PBXProject "swift-ios-27" */,
+			);
+			defaultConfigurationName = Release;
+		};
+		000000000000000110000000 /* Build configuration list for PBXNativeTarget "swift-ios-27" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000111000000 /* Debug configuration for PBXNativeTarget "swift-ios-27" */,
+				000000000000000112000000 /* Release configuration for PBXNativeTarget "swift-ios-27" */,
+			);
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 000000000000000000000000 /* Project object */;
+}

--- a/src/json/__tests__/json.test.ts
+++ b/src/json/__tests__/json.test.ts
@@ -34,6 +34,7 @@ describe(parse, () => {
     "008-out-of-order-orphans.pbxproj",
     "009-expo-app-clip.pbxproj",
     "010-swiftui-multiplatform.pbxproj",
+    "011-swift-ios-27.pbxproj",
     "shopify-tophat.pbxproj",
     "AFNetworking.pbxproj",
     "project.pbxproj",
@@ -70,6 +71,10 @@ describe(parse, () => {
     "006-spm.pbxproj",
     "007-xcode16.pbxproj",
     "010-swiftui-multiplatform.pbxproj",
+    // Known formatting diff: Xcode 27 emits verbose XCBuildConfiguration
+    // comments (e.g. `Debug configuration for PBXProject "..."`) that the
+    // writer doesn't reproduce, so this only goes in the parse `fixtures`.
+    // "011-swift-ios-27.pbxproj",
 
     "AFNetworking.pbxproj",
     "project.pbxproj",

--- a/src/json/__tests__/json.test.ts
+++ b/src/json/__tests__/json.test.ts
@@ -71,10 +71,7 @@ describe(parse, () => {
     "006-spm.pbxproj",
     "007-xcode16.pbxproj",
     "010-swiftui-multiplatform.pbxproj",
-    // Known formatting diff: Xcode 27 emits verbose XCBuildConfiguration
-    // comments (e.g. `Debug configuration for PBXProject "..."`) that the
-    // writer doesn't reproduce, so this only goes in the parse `fixtures`.
-    // "011-swift-ios-27.pbxproj",
+    "011-swift-ios-27.pbxproj",
 
     "AFNetworking.pbxproj",
     "project.pbxproj",

--- a/src/json/comments.ts
+++ b/src/json/comments.ts
@@ -15,16 +15,37 @@ export function createReferenceList(
   const strict = false;
   const objects: Record<string, any> = project?.objects ?? {};
 
+  // Xcode 27.0 writes pbxproj files with `objectVersion = 90`, which introduced
+  // a more descriptive comment style for build configurations, e.g.
+  // `Debug configuration for PBXNativeTarget "App"` instead of just `Debug`.
+  const usesVerboseConfigComments = Number(project?.objectVersion) >= 90;
+
   const referenceCache: Record<string, string> = {};
 
-  function getXCConfigurationListComment(id: string) {
+  /**
+   * Resolve the object that owns a given `XCConfigurationList` (the target or
+   * project whose `buildConfigurationList` points at it) and return its `isa`
+   * and display name, matching the values Xcode embeds in pbxproj comments.
+   */
+  function getConfigurationListOwner(
+    id: string
+  ): { isa: string; name: string } | null {
     for (const [innerId, obj] of Object.entries(objects) as any) {
       if (obj.buildConfigurationList === id) {
         let name = obj.name ?? obj.path ?? obj.productName;
         if (!name) {
+          // The main `PBXProject` object has no name; Xcode labels it with the
+          // project name, which the built product is named after. Derive it from
+          // the first target's product reference (e.g. `App.app` -> `App`),
+          // falling back to the target's name/productName.
+          const firstTarget = objects[obj.targets?.[0]];
+          const productPath =
+            objects[firstTarget?.productReference]?.path ??
+            objects[firstTarget?.productReference]?.name;
           name =
-            objects[obj.targets?.[0]]?.productName ??
-            objects[obj.targets?.[0]]?.name;
+            (productPath && productPath.replace(/\.[^.]+$/, "")) ??
+            firstTarget?.productName ??
+            firstTarget?.name;
 
           if (!name) {
             // NOTE(EvanBacon): I have no idea what I'm doing...
@@ -39,10 +60,37 @@ export function createReferenceList(
           }
         }
 
-        return `Build configuration list for ${obj.isa} "${name}"`;
+        return { isa: obj.isa, name };
       }
     }
-    return `Build configuration list for [unknown]`;
+    return null;
+  }
+
+  function getXCConfigurationListComment(id: string) {
+    const owner = getConfigurationListOwner(id);
+    if (!owner) {
+      return `Build configuration list for [unknown]`;
+    }
+    return `Build configuration list for ${owner.isa} "${owner.name}"`;
+  }
+
+  function getXCBuildConfigurationComment(id: string, object: any): string {
+    // Older pbxproj versions just use the configuration name (e.g. `Debug`).
+    if (!usesVerboseConfigComments) {
+      return object.name ?? "";
+    }
+    // Find the configuration list that contains this build configuration, then
+    // describe it in terms of its owning target/project.
+    for (const [listId, obj] of Object.entries(objects) as any) {
+      if (obj.isa === "XCConfigurationList" && obj.buildConfigurations?.includes(id)) {
+        const owner = getConfigurationListOwner(listId);
+        if (owner) {
+          return `${object.name} configuration for ${owner.isa} "${owner.name}"`;
+        }
+        break;
+      }
+    }
+    return object.name ?? "";
   }
 
   function getBuildPhaseNameContainingFile(buildFileId: string): string | null {
@@ -81,6 +129,8 @@ export function createReferenceList(
       referenceCache[id] = getPBXBuildFileComment(id, object);
     } else if (isXCConfigurationList(object)) {
       referenceCache[id] = getXCConfigurationListComment(id);
+    } else if (object.isa === "XCBuildConfiguration") {
+      referenceCache[id] = getXCBuildConfigurationComment(id, object);
     } else if (isXCRemoteSwiftPackageReference(object)) {
       if (object.repositoryURL) {
         referenceCache[id] = `${object.isa} "${getRepoNameFromURL(

--- a/src/json/types.ts
+++ b/src/json/types.ts
@@ -1016,9 +1016,13 @@ export interface BuildSettings {
   IPHONEOS_DEPLOYMENT_TARGET?: string;
   MACOSX_DEPLOYMENT_TARGET?: string;
   TVOS_DEPLOYMENT_TARGET?: string;
+  /** tvOS deployment target version, using the legacy `APPLETVOS` SDK name. Emitted by newer Xcode templates alongside `TVOS_DEPLOYMENT_TARGET`. @since Xcode 7.1 @example `"27.0"` */
+  APPLETVOS_DEPLOYMENT_TARGET?: string;
   WATCHOS_DEPLOYMENT_TARGET?: string;
   /** visionOS deployment target version. @example `"2.0"` */
   XROS_DEPLOYMENT_TARGET?: string;
+  /** DriverKit deployment target version. @since Xcode 11.0 @example `"27.0"` */
+  DRIVERKIT_DEPLOYMENT_TARGET?: string;
 
   /** The name of the build setting for the deployment target for the effective platform. */
   DEPLOYMENT_TARGET_SETTING_NAME?: string;
@@ -1443,6 +1447,31 @@ export interface BuildSettings {
   /** Must contain a profile name (or UUID). */
   PROVISIONING_PROFILE_SPECIFIER?: string;
 
+  /** Register app groups in provisioning profiles. Emitted by newer Xcode templates that use App Groups. @since Xcode 16.0 */
+  REGISTER_APP_GROUPS?: BoolString;
+
+  /** Enables distribution of the app via Web Distribution in the EU (iOS 17.5+). @since Xcode 15.4 */
+  ALTERNATIVE_DISTRIBUTION_WEB?: BoolString;
+
+  /** The list of alternative app marketplaces this app may be distributed through in the EU (iOS 17.4+). @since Xcode 15.3 */
+  MARKETPLACES?: string[];
+
+  // ============================================================================
+  // Launch & Library Load Constraints (iOS 17 / macOS 14+)
+  // ============================================================================
+
+  /** Path to a launch environment constraint plist applied to the parent process. @since Xcode 15.0 */
+  LAUNCH_CONSTRAINT_PARENT?: string;
+
+  /** Path to a launch environment constraint plist applied to the responsible process. @since Xcode 15.0 */
+  LAUNCH_CONSTRAINT_RESPONSIBLE?: string;
+
+  /** Path to a launch environment constraint plist applied to the process itself. @since Xcode 15.0 */
+  LAUNCH_CONSTRAINT_SELF?: string;
+
+  /** Path to a library load constraint plist restricting which processes may load this library. @since Xcode 15.0 */
+  LIBRARY_LOAD_CONSTRAINT?: string;
+
   // ============================================================================
   // Swift Settings
   // ============================================================================
@@ -1470,6 +1499,12 @@ export interface BuildSettings {
 
   /** Enables the use of the forward slash syntax for regular-expressions. */
   SWIFT_ENABLE_BARE_SLASH_REGEX?: BoolString;
+
+  /** Build the target with the Embedded Swift language subset, producing standalone binaries without the full Swift runtime. @since Xcode 27.0 */
+  SWIFT_ENABLE_EMBEDDED?: BoolString;
+
+  /** Enables the compilation cache for Swift, reusing previous compilation results. Defaults to `$(COMPILATION_CACHE_ENABLE_CACHING)`. @since Xcode 16.0 */
+  SWIFT_ENABLE_COMPILE_CACHE?: BoolString;
 
   /** Emit the extracted compile-time known values from the Swift compiler. */
   SWIFT_ENABLE_EMIT_CONST_VALUES?: BoolString;
@@ -1604,6 +1639,12 @@ export interface BuildSettings {
 
   /** Enables the use of modules for system APIs. */
   CLANG_ENABLE_MODULES?: BoolString;
+
+  /** Builds Clang module dependencies via explicit tasks rather than implicitly during compilation. Defaults to `YES`. @since Xcode 16.0 */
+  CLANG_ENABLE_EXPLICIT_MODULES?: BoolString;
+
+  /** Enables the compilation cache for Clang, reusing previous compilation results. Defaults to `$(COMPILATION_CACHE_ENABLE_CACHING)`. @since Xcode 16.0 */
+  CLANG_ENABLE_COMPILE_CACHE?: BoolString;
 
   /** When enabled, `clang` will use the shared debug info available in `clang` modules and precompiled headers. */
   CLANG_ENABLE_MODULE_DEBUGGING?: BoolString;
@@ -2636,6 +2677,15 @@ export interface BuildSettings {
   /** When enabled, includes the localization information of the selected assets in the generated partial Info.plist file. */
   ASSETCATALOG_COMPILER_INCLUDE_INFOPLIST_LOCALIZATIONS?: BoolString;
 
+  /** When enabled, includes sticker pack content from the target's asset catalogs in the built product. @since Xcode 8.0 */
+  ASSETCATALOG_COMPILER_INCLUDE_STICKER_CONTENT?: BoolString;
+
+  /** The role the target's sticker icon plays, when building a Messages sticker target. @since Xcode 8.0 */
+  ASSETCATALOG_COMPILER_TARGET_STICKERS_ICON_ROLE?:
+    | "host-app"
+    | "extension"
+    | (string & {});
+
   /** Name of an asset catalog launch image set whose contents will be merged into the `Info.plist`. */
   ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME?: string;
 
@@ -2768,6 +2818,12 @@ export interface BuildSettings {
   /** When enabled, localizable content in this target/project can be exported. */
   LOCALIZATION_EXPORT_SUPPORTED?: BoolString;
 
+  /** When enabled, only builds content for languages explicitly supported by the project. @since Xcode 15.0 */
+  BUILD_ONLY_KNOWN_LOCALIZATIONS?: BoolString;
+
+  /** When enabled, localizable strings wrapped in NSLocalizedString-like macros are extracted even if commented out or wrapped in `#if 0`. @since Xcode 15.0 */
+  LOCALIZED_STRING_CODE_COMMENTS?: BoolString;
+
   /** When enabled, string tables generated in a localization export will prefer the String Catalog format. */
   LOCALIZATION_PREFERS_STRING_CATALOGS?: BoolString;
 
@@ -2808,6 +2864,25 @@ export interface BuildSettings {
 
   /** When enabled, generates assets needed for App Shortcuts Flexible Matching. */
   APP_SHORTCUTS_ENABLE_FLEXIBLE_MATCHING?: BoolString;
+
+  /** Defines how a Core ML / AI model is built for deployment in the product bundle. @since Xcode 27.0 */
+  AIMODEL_BUILD_TYPE?: "package" | "compile" | (string & {});
+
+  /** Specifies the chips where AI model asset inference may run. @since Xcode 27.0 */
+  AIMODEL_INFERENCE_MODE?: "default" | "cpu-only" | (string & {});
+
+  /** Enables code size profiling for the build, emitting reports to `CODESIZE_PROFILE_OUTPUT_DIR`. @since Xcode 27.0 */
+  ENABLE_CODESIZE_PROFILE?: BoolString;
+
+  /** Indicates the target supports Text-Based InstallAPI (`.tbd` generation), enabling its generation during `install` builds. @since Xcode 11.0 */
+  SUPPORTS_TEXT_BASED_API?: BoolString;
+
+  /**
+   * A per-project random value injected by newer Xcode templates, used to keep generated
+   * bundle identifiers unique (e.g. `devplaceholder.$(PROJECT_UNIQUE_VALUE:identifier).$(PRODUCT_NAME:identifier)`).
+   * @since Xcode 16.0
+   */
+  PROJECT_UNIQUE_VALUE?: string;
 
   /** A Boolean value that indicates whether the app may prompt the user for permission to send Apple events. */
   AUTOMATION_APPLE_EVENTS?: BoolString;


### PR DESCRIPTION
## Summary

Brings `@bacons/xcode` up to date with Xcode 27.

- **New build settings** in `src/json/types.ts` — adds 22 modern/Xcode-27 settings (deployment targets, launch & library load constraints, EU alternative distribution, AI model build, compilation caching, explicit modules, Embedded Swift, sticker asset catalog options, localization, etc.), each with a `@since` annotation denoting first availability.
- **Verbose configuration comments** — when `objectVersion >= 90` (Xcode 27.0), the writer now emits the descriptive comment style, e.g. `Debug configuration for PBXNativeTarget "App"` instead of the bare `Debug`. Older project versions keep the terse form.
- **Fixed `PBXProject` name resolution** — the unnamed project object is now labeled from the first target's product reference basename (`App.app` → `App`), matching Xcode. This also corrects the existing build-configuration-list comment for projects where the target `name` and `productName` diverge.
- **New fixture** `011-swift-ios-27.pbxproj` added to both the parse and round-trip test arrays; it round-trips byte-for-byte.

## Test plan

- `bun test` — 661 pass / 0 fail
- `npx tsc --noEmit` — clean